### PR TITLE
chore: prefer standard field `pkg.exports`

### DIFF
--- a/libs/node-ts-esm-esbuild/package.json
+++ b/libs/node-ts-esm-esbuild/package.json
@@ -11,7 +11,6 @@
 	],
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"module": "./dist/index.js",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",

--- a/libs/node-ts-esm-rollup/package.json
+++ b/libs/node-ts-esm-rollup/package.json
@@ -11,7 +11,6 @@
 	],
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"module": "./dist/index.js",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",

--- a/libs/node-ts-esm-vite/package.json
+++ b/libs/node-ts-esm-vite/package.json
@@ -5,7 +5,6 @@
 	"description": "Node, TypeScript (ESM), Vite",
 	"type": "module",
 	"types": "./dist/index.d.ts",
-	"module": "./dist/index.mjs",
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",


### PR DESCRIPTION
This removes the non-standard field `pkg.module` in favor of the standard field `pkg.exports`, specified by Node.js.