### PR TITLE
chore(npm): make script name consistent for generating .d.ts files

### DIFF
--- a/libs/node-js-cjs-esbuild/package.json
+++ b/libs/node-js-cjs-esbuild/package.json
@@ -22,8 +22,8 @@
 		"dist"
 	],
 	"scripts": {
-		"build": "npm run types && node build.js",
-		"types": "tsc",
+		"build": "npm run dts && node build.js",
+		"dts": "tsc",
 		"prepublint": "npm run build",
 		"publint": "publint ."
 	},

--- a/libs/node-ts-esm-esbuild/package.json
+++ b/libs/node-ts-esm-esbuild/package.json
@@ -21,8 +21,8 @@
 		"dist"
 	],
 	"scripts": {
-		"build": "npm run types && node build.js",
-		"types": "tsc",
+		"build": "npm run dts && node build.js",
+		"dts": "tsc",
 		"prepublint": "npm run build",
 		"publint": "publint ."
 	},


### PR DESCRIPTION
This keeps it inline with how node-js-cjs-parcel and node-js-cjs-webpack specify the script name as "dts".