### PR TITLE
chore(npm): remove leftover non-standard key in package.json

### DIFF
--- a/libs/node-ts-esm-parcel/package.json
+++ b/libs/node-ts-esm-parcel/package.json
@@ -12,7 +12,6 @@
 	"type": "module",
 	"source": "./src/index.ts",
 	"types": "./dist/types.d.ts",
-	"module": "./dist/module.js",
 	"exports": {
 		".": {
 			"types": "./dist/types.d.ts",


### PR DESCRIPTION
Removes last leftover in node-ts-esm-parcel, followup to #27